### PR TITLE
Update the app Meta to use Semantic Version

### DIFF
--- a/src/api_integration_test.go
+++ b/src/api_integration_test.go
@@ -213,7 +213,7 @@ var scenarios = []struct {
 			{"POST", "/apps", appWithoutVersion},
 		},
 		400,
-		`{"error":"Key: 'Meta.Version' Error:Field validation for 'Version' failed on the 'required' tag"}`,
+		`{"error":"App 'App4' lacks of version or the version could not be '0.0.0'.)"}`,
 	},
 	{
 		"Create app with bad maintainer email, response 400",

--- a/src/api_integration_test.go
+++ b/src/api_integration_test.go
@@ -106,6 +106,22 @@ description: |
  ### Interesting Title
  Some application content, and description
 `
+const appWithBadVersion = `
+title: App4
+version: 0.0.a
+maintainers:
+- name: firstmaintainer app1
+  email: firstmaintainer@hotmail.com
+- name: secondmaintainer app1
+  email: secondmaintainer@gmail.com
+company: Random Inc.
+website: https://website.com
+source: https://github.com/random/repo
+license: Apache-2.0
+description: |
+ ### Interesting Title
+ Some application content, and description
+`
 const appWithBadMaintainerEmail = `
 title: App5
 version: 0.0.1
@@ -214,6 +230,14 @@ var scenarios = []struct {
 		},
 		400,
 		`{"error":"App 'App4' lacks of version or the version could not be '0.0.0'.)"}`,
+	},
+	{
+		"Create app with bad version, response 400",
+		[]Request{
+			{"POST", "/apps", appWithBadVersion},
+		},
+		400,
+		`{"error":"Failed to parse version '0.0.a': Invalid character(s) found in number \"a\""}`,
 	},
 	{
 		"Create app with bad maintainer email, response 400",

--- a/src/app/meta.go
+++ b/src/app/meta.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/zzn2/demo/appstore/filter"
+	"github.com/zzn2/demo/appstore/semver"
 	"gopkg.in/yaml.v2"
 )
 
@@ -15,14 +16,14 @@ type Maintainer struct {
 }
 
 type Meta struct {
-	Title       string       `binding:"required"`
-	Version     string       `binding:"required"`
-	Maintainers []Maintainer `binding:"required,dive"`
-	Company     string       `binding:"required"`
-	Website     string       `binding:"required,url"`
-	Source      string       `binding:"required"`
-	License     string       `binding:"required"`
-	Description string       `binding:"required"`
+	Title       string         `binding:"required"`
+	Version     semver.Version `binding:"required"`
+	Maintainers []Maintainer   `binding:"required,dive"`
+	Company     string         `binding:"required"`
+	Website     string         `binding:"required,url"`
+	Source      string         `binding:"required"`
+	License     string         `binding:"required"`
+	Description string         `binding:"required"`
 }
 
 // Parse parses an yaml text into the Meta struct.
@@ -46,7 +47,7 @@ func (m *Meta) MatchRule(rule filter.Rule) (bool, error) {
 	case "title":
 		return rule.Evaluate(m.Title)
 	case "version":
-		return rule.Evaluate(m.Version)
+		return rule.Evaluate(m.Version.String())
 	case "maintainer.name":
 		for _, maintainer := range m.Maintainers {
 			match, err := rule.Evaluate(maintainer.Name)

--- a/src/app/store.go
+++ b/src/app/store.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/zzn2/demo/appstore/filter"
+	"github.com/zzn2/demo/appstore/semver"
 )
 
 // Store stores metadata of apps.
@@ -20,6 +21,10 @@ var modifyLock sync.Mutex
 // Add a new app metadata into the store.
 // It returns error if the store already contains an app with the same title and version.
 func (s *Store) Add(app Meta) error {
+	if app.Version == semver.Empty {
+		return errors.New(fmt.Sprintf("App '%s' lacks of version or the version could not be '%s'.)", app.Title, app.Version))
+	}
+
 	if s.GetByTitleAndVersion(app.Title, app.Version) != nil {
 		return errors.New(fmt.Sprintf("App '%s' with version '%s' already exists.", app.Title, app.Version))
 	}
@@ -42,7 +47,7 @@ func (s *Store) GetByTitle(title string) *Meta {
 
 // GetByTitleAndVersion gets an app metadata using title and version.
 // It returns the matching metadata if exists, otherwise returns nil.
-func (s *Store) GetByTitleAndVersion(title string, version string) *Meta {
+func (s *Store) GetByTitleAndVersion(title string, version semver.Version) *Meta {
 	// If multiple found, return the last one, which is likely to be the latest version.
 	// TODO: Should add version comparing logic here and only return the latest version.
 	return s.lastOrNil(func(app Meta) bool {

--- a/src/app/store_test.go
+++ b/src/app/store_test.go
@@ -4,22 +4,29 @@ import (
 	"testing"
 
 	"github.com/zzn2/demo/appstore/filter"
+	"github.com/zzn2/demo/appstore/semver"
+)
+
+var (
+	v_0_0_1 = semver.Version{Major: 0, Minor: 0, Patch: 1}
+	v_0_0_2 = semver.Version{Major: 0, Minor: 0, Patch: 2}
+	v_0_0_3 = semver.Version{Major: 0, Minor: 0, Patch: 3}
 )
 
 var (
 	app1v1 = Meta{
 		Title:   "App1",
-		Version: "0.0.1",
+		Version: v_0_0_1,
 	}
 
 	app1v2 = Meta{
 		Title:   "App1",
-		Version: "0.0.2",
+		Version: v_0_0_2,
 	}
 
 	app2v1 = Meta{
 		Title:   "App2",
-		Version: "0.0.1",
+		Version: v_0_0_1,
 	}
 )
 
@@ -95,27 +102,27 @@ func TestGetByTitleAndVersion(t *testing.T) {
 	store.Add(app1v2)
 	store.Add(app2v1)
 
-	result1 := store.GetByTitleAndVersion("App1", "0.0.1")
+	result1 := store.GetByTitleAndVersion("App1", v_0_0_1)
 	if !equals(*result1, app1v1) {
 		t.Errorf("Expected to be '%s' but got '%s'", result1, app1v2)
 	}
 
-	result2 := store.GetByTitleAndVersion("App1", "0.0.2")
+	result2 := store.GetByTitleAndVersion("App1", v_0_0_2)
 	if !equals(*result2, app1v2) {
 		t.Errorf("Expected to be '%s' but got '%s'", result2, app1v2)
 	}
 
-	result3 := store.GetByTitleAndVersion("App1", "0.0.3")
+	result3 := store.GetByTitleAndVersion("App1", v_0_0_3)
 	if result3 != nil {
 		t.Errorf("Expected to be nil but got '%s'", result3)
 	}
 
-	result4 := store.GetByTitleAndVersion("App2", "0.0.1")
+	result4 := store.GetByTitleAndVersion("App2", v_0_0_1)
 	if !equals(*result4, app2v1) {
 		t.Errorf("Expected to be '%s' but got '%s'", result4, app2v1)
 	}
 
-	result5 := store.GetByTitleAndVersion("App3", "0.0.1")
+	result5 := store.GetByTitleAndVersion("App3", v_0_0_1)
 	if result5 != nil {
 		t.Errorf("Expected to be nil but got '%s'", result5)
 	}

--- a/src/semver/version.go
+++ b/src/semver/version.go
@@ -48,34 +48,28 @@ func parseSection(text string) (uint64, error) {
 
 func Parse(s string) (Version, error) {
 	if len(s) == 0 {
-		return Version{}, errors.New("Version string empty")
+		return Version{}, errors.New("Failed to parse version: Empty string")
 	}
 
 	// Split into major.minor.(patch+pr+meta)
 	parts := strings.SplitN(s, ".", 3)
 	if len(parts) != 3 {
-		return Version{}, errors.New("No Major.Minor.Patch elements found")
+		return Version{}, fmt.Errorf("Failed to parse version '%s': Version text must be in 'Major.Minor.Patch' format", s)
 	}
 
-	major, err := parseSection(parts[0])
-	if err != nil {
-		return Version{}, err
-	}
-
-	minor, err := parseSection(parts[1])
-	if err != nil {
-		return Version{}, err
-	}
-
-	patch, err := parseSection(parts[2])
-	if err != nil {
-		return Version{}, err
+	sections := make([]uint64, 3)
+	for i := range sections {
+		val, err := parseSection(parts[i])
+		if err != nil {
+			return Version{}, fmt.Errorf("Failed to parse version '%s': %w", s, err)
+		}
+		sections[i] = val
 	}
 
 	v := Version{}
-	v.Major = major
-	v.Minor = minor
-	v.Patch = patch
+	v.Major = sections[0]
+	v.Minor = sections[1]
+	v.Patch = sections[2]
 
 	return v, nil
 }

--- a/src/semver/version.go
+++ b/src/semver/version.go
@@ -1,0 +1,107 @@
+// Package semver provides parsing and validation logic for [Semantic Versioning](https://semver.org/).
+//
+// Note:
+//   1. Here we only implementing a subset of Semantic Versioning just for demo usage.
+//   2. Most of the code referred to the implemention of https://github.com/blang/semver.
+package semver
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major uint64
+	Minor uint64
+	Patch uint64
+}
+
+var Empty = Version{}
+
+func containsOnly(s string, set string) bool {
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(set, r)
+	}) == -1
+}
+
+func hasLeadingZeroes(s string) bool {
+	return len(s) > 1 && s[0] == '0'
+}
+
+func parseSection(text string) (uint64, error) {
+	if !containsOnly(text, "0123456789") {
+		return 0, fmt.Errorf("Invalid character(s) found in number %q", text)
+	}
+	if hasLeadingZeroes(text) {
+		return 0, fmt.Errorf("Version sections must not contain leading zeroes: %q", text)
+	}
+
+	res, err := strconv.ParseUint(text, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return res, nil
+}
+
+func Parse(s string) (Version, error) {
+	if len(s) == 0 {
+		return Version{}, errors.New("Version string empty")
+	}
+
+	// Split into major.minor.(patch+pr+meta)
+	parts := strings.SplitN(s, ".", 3)
+	if len(parts) != 3 {
+		return Version{}, errors.New("No Major.Minor.Patch elements found")
+	}
+
+	major, err := parseSection(parts[0])
+	if err != nil {
+		return Version{}, err
+	}
+
+	minor, err := parseSection(parts[1])
+	if err != nil {
+		return Version{}, err
+	}
+
+	patch, err := parseSection(parts[2])
+	if err != nil {
+		return Version{}, err
+	}
+
+	v := Version{}
+	v.Major = major
+	v.Minor = minor
+	v.Patch = patch
+
+	return v, nil
+}
+
+func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var text string
+	err := unmarshal(&text)
+	if err != nil {
+		return err
+	}
+
+	version, err := Parse(text)
+	if err != nil {
+		return err
+	}
+
+	v.Major = version.Major
+	v.Minor = version.Minor
+	v.Patch = version.Patch
+	return nil
+}
+
+func (v Version) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("%q", v.String())), nil
+}
+
+func (v Version) String() string {
+	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}

--- a/src/semver/version.go
+++ b/src/semver/version.go
@@ -1,8 +1,8 @@
-// Package semver provides parsing and validation logic for [Semantic Versioning](https://semver.org/).
+// Package semver provides parsing and validation logic for [Semantic Version](https://semver.org/)s.
 //
 // Note:
-//   1. Here we only implementing a subset of Semantic Versioning just for demo usage.
-//   2. Most of the code referred to the implemention of https://github.com/blang/semver.
+//   1. Here we only implement subset of Semantic Versioning just for demo usage.
+//   2. Most of the code referred the implemention from https://github.com/blang/semver.
 package semver
 
 import (
@@ -46,6 +46,8 @@ func parseSection(text string) (uint64, error) {
 	return res, nil
 }
 
+// Parse parses a text into a Version object.
+// errors will be returned if the text is not a valid format.
 func Parse(s string) (Version, error) {
 	if len(s) == 0 {
 		return Version{}, errors.New("Failed to parse version: Empty string")
@@ -74,6 +76,7 @@ func Parse(s string) (Version, error) {
 	return v, nil
 }
 
+// UnmarshalYAML will be called when deserializing a Version object from part of YAML text.
 func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var text string
 	err := unmarshal(&text)
@@ -92,10 +95,12 @@ func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// MarshalJSON will be called when serializing a Version object into text as part of json.
 func (v Version) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("%q", v.String())), nil
 }
 
+// String returns the string representation of the Version object.
 func (v Version) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
 }

--- a/src/semver/version_test.go
+++ b/src/semver/version_test.go
@@ -10,9 +10,10 @@ func TestEvaluate(t *testing.T) {
 	}{
 		{"0.0.1", Version{0, 0, 1}, ""},
 		{"1.0.1", Version{1, 0, 1}, ""},
-		{"-1.0.1", Version{0, 0, 0}, `Invalid character(s) found in number "-1"`},
-		{"01.0.1", Version{0, 0, 0}, `Version sections must not contain leading zeroes: "01"`},
-		{"0.1", Version{0, 0, 0}, `No Major.Minor.Patch elements found`},
+		{"-1.0.1", Version{0, 0, 0}, `Failed to parse version '-1.0.1': Invalid character(s) found in number "-1"`},
+		{"01.0.1", Version{0, 0, 0}, `Failed to parse version '01.0.1': Version sections must not contain leading zeroes: "01"`},
+		{"0.1", Version{0, 0, 0}, `Failed to parse version '0.1': Version text must be in 'Major.Minor.Patch' format`},
+		{"", Version{0, 0, 0}, `Failed to parse version: Empty string`},
 	}
 
 	for _, tt := range tests {

--- a/src/semver/version_test.go
+++ b/src/semver/version_test.go
@@ -1,0 +1,50 @@
+package semver
+
+import "testing"
+
+func TestEvaluate(t *testing.T) {
+	var tests = []struct {
+		text         string
+		expected     Version
+		errorMessage string
+	}{
+		{"0.0.1", Version{0, 0, 1}, ""},
+		{"1.0.1", Version{1, 0, 1}, ""},
+		{"-1.0.1", Version{0, 0, 0}, `Invalid character(s) found in number "-1"`},
+		{"01.0.1", Version{0, 0, 0}, `Version sections must not contain leading zeroes: "01"`},
+		{"0.1", Version{0, 0, 0}, `No Major.Minor.Patch elements found`},
+	}
+
+	for _, tt := range tests {
+		testname := tt.text
+		t.Run(testname, func(t *testing.T) {
+			v, err := Parse(tt.text)
+			if v != tt.expected {
+				t.Errorf("Expect to be '%v' but got '%v'", tt.expected, v)
+			}
+			if err != nil {
+				if err.Error() != tt.errorMessage {
+					t.Errorf("Expect error message '%s' but got '%s'.", tt.errorMessage, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestString(t *testing.T) {
+	var tests = []struct {
+		version Version
+		text    string
+	}{
+		{Version{0, 0, 1}, "0.0.1"},
+		{Version{1, 0, 0}, "1.0.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.text, func(t *testing.T) {
+			if tt.version.String() != tt.text {
+				t.Errorf("Expect to be '%s' but got '%s'.", tt.text, tt.version)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The `app.Meta.Version` field was `string` type.
In this PR, change it to `semver.Version` type to make it compatible to the [Semantic Versioning](https://semver.org/) specification.