### PR TITLE
Add support to filter apps by version ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,17 @@ GET /apps?title=App1
 
 Filters could be applied to multiple fields:
 ```
-GET /apps?title=App1&versions=0.0.1
+GET /apps?title=App1&version=0.0.1
 ```
 
 Filters can also be non-precise match by specifying [LHS Brackets](https://christiangiacomi.com/posts/rest-design-principles/). For example, the following query lists apps which title contains "App":
 ```
 GET /apps?title[like]=App
+```
+
+"LessThan" or "GreaterThan" operator can be used to list apps with specific version range:
+```
+GET /apps?title=App1&version[gt]=0.0.2
 ```
 
 Refer to [integration test scenarios](src/api_integration_test.go) for more use cases.

--- a/src/api_integration_test.go
+++ b/src/api_integration_test.go
@@ -380,7 +380,7 @@ var scenarios = []struct {
 		]`,
 	},
 	{
-		"List apps, filter with app title (multiple results)",
+		"List apps, filter with app title, multiple results",
 		[]Request{
 			{"POST", "/apps", app1v1},
 			{"POST", "/apps", app1v2},
@@ -394,7 +394,7 @@ var scenarios = []struct {
 		]`,
 	},
 	{
-		"List apps, filter with app title (single result)",
+		"List apps, filter with app title, single result",
 		[]Request{
 			{"POST", "/apps", app1v1},
 			{"POST", "/apps", app1v2},
@@ -407,7 +407,7 @@ var scenarios = []struct {
 		]`,
 	},
 	{
-		"List apps, filter with app title (no result)",
+		"List apps, filter with app title, no result",
 		[]Request{
 			{"POST", "/apps", app1v1},
 			{"POST", "/apps", app1v2},
@@ -446,6 +446,30 @@ var scenarios = []struct {
 		]`,
 	},
 	{
+		"List apps, filter with version comparision",
+		[]Request{
+			{"POST", "/apps", app1v1},
+			{"POST", "/apps", app1v2},
+			{"POST", "/apps", app2v1},
+			{"GET", "/apps?title=App1&version[gt]=0.0.1", ""},
+		},
+		200,
+		`[
+			{"Title":"App1","Version":"0.0.2","Maintainers":[{"Name":"firstmaintainer app1","Email":"firstmaintainer@hotmail.com"},{"Name":"secondmaintainer app1","Email":"secondmaintainer@gmail.com"}],"Company":"Random Inc.","Website":"https://website.com","Source":"https://github.com/random/repo","License":"Apache-2.0","Description":"### Interesting Title\nSome application content, and description\n"}
+		]`,
+	},
+	{
+		"List apps, filter with app name comparision, will fail",
+		[]Request{
+			{"POST", "/apps", app1v1},
+			{"POST", "/apps", app1v2},
+			{"POST", "/apps", app2v1},
+			{"GET", "/apps?title[lt]=App1", ""},
+		},
+		400,
+		`{"error":"Failed to create rule: Type 'string' does not support 'LessThan' operator"}`,
+	},
+	{
 		"List apps, filter with bad field names",
 		[]Request{
 			{"POST", "/apps", app1v1},
@@ -454,7 +478,7 @@ var scenarios = []struct {
 			{"GET", "/apps?title=App1&dummy=unknown", ""},
 		},
 		400,
-		`{"error":"Error occurred during searching app: Unsupported rule for field 'dummy'"}[]`,
+		`{"error":"Failed to create rule: Field with name 'dummy' does not exist."}`,
 	},
 	{
 		"List apps, filter with bad operator",

--- a/src/app/meta.go
+++ b/src/app/meta.go
@@ -1,13 +1,9 @@
 package app
 
 import (
-	"errors"
 	"fmt"
-	"strings"
 
-	"github.com/zzn2/demo/appstore/filter"
 	"github.com/zzn2/demo/appstore/semver"
-	"gopkg.in/yaml.v2"
 )
 
 type Maintainer struct {
@@ -24,68 +20,6 @@ type Meta struct {
 	Source      string         `binding:"required"`
 	License     string         `binding:"required"`
 	Description string         `binding:"required"`
-}
-
-// Parse parses an yaml text into the Meta struct.
-// It returns nil along with the error if any error occurred during the parse.
-func Parse(data []byte) (*Meta, error) {
-	var m Meta
-	if err := yaml.Unmarshal(data, &m); err != nil {
-		return nil, err
-	}
-
-	return &m, nil
-}
-
-// MatchRule evaluates whether this Meta matches the given rule.
-// It returns true if matches otherwise returns false.
-// If any unexpected errors occurred during match operation, return the error.
-func (m *Meta) MatchRule(rule filter.Rule) (bool, error) {
-	// TODO: embed the logic into the struct using struct tags
-	// https://www.digitalocean.com/community/tutorials/how-to-use-struct-tags-in-go
-	switch strings.ToLower(rule.FieldName) {
-	case "title":
-		return rule.Evaluate(m.Title)
-	case "version":
-		return rule.Evaluate(m.Version.String())
-	case "maintainer.name":
-		for _, maintainer := range m.Maintainers {
-			match, err := rule.Evaluate(maintainer.Name)
-			if err != nil {
-				return false, err
-			}
-			if match {
-				// Early return when the first match found.
-				// If not found, do not return and go to next loop.
-				return true, nil
-			}
-		}
-		// All maintainers not match if goes to this line.
-		return false, nil
-	case "company":
-		return rule.Evaluate(m.Company)
-	case "description":
-		return rule.Evaluate(m.Description)
-	default:
-		return false, errors.New(fmt.Sprintf("Unsupported rule for field '%s'", rule.FieldName))
-	}
-}
-
-// MatchRuleSet evaluates whether this Meta matches the given ruleset.
-// It returns true if matches otherwise returns false.
-// If any unexpected errors occurred during match operation, return the error.
-func (m *Meta) MatchRuleSet(ruleSet filter.RuleSet) (bool, error) {
-	for _, rule := range ruleSet.Rules {
-		match, err := m.MatchRule(rule)
-		if err != nil {
-			return false, err
-		}
-		if !match {
-			return false, nil
-		}
-	}
-
-	return true, nil
 }
 
 // String returns the string representation of this object.

--- a/src/app/meta_test.go
+++ b/src/app/meta_test.go
@@ -3,91 +3,34 @@ package app
 import (
 	"testing"
 
-	"github.com/zzn2/demo/appstore/filter"
+	"github.com/zzn2/demo/appstore/semver"
 )
 
-const sampleInput = `
-title: Valid App 1
-version: 0.0.1
-maintainers:
-- name: firstmaintainer app1
-  email: firstmaintainer@hotmail.com
-- name: secondmaintainer app1
-  email: secondmaintainer@gmail.com
-company: Random Inc.
-website: https://website.com
-source: https://github.com/random/repo
-license: Apache-2.0
-description: |
- ### Interesting Title
+var app = Meta{
+	Title:   "Valid App 1",
+	Version: semver.Version{Major: 0, Minor: 0, Patch: 1},
+	Maintainers: []Maintainer{
+		{
+			Name:  "Alice",
+			Email: "alice@hotmail.com",
+		},
+		{
+			Name:  "Bob",
+			Email: "bob@gmail.com",
+		},
+	},
+	Company: "Random Inc.",
+	Website: "https://website.com",
+	Source:  "https://github.com/random/repo",
+	License: "Apache-2.0",
+	Description: `
+ ### Intresting Title
  Some application content, and description
-`
-
-func TestParse(t *testing.T) {
-	app, err := Parse([]byte(sampleInput))
-
-	if err != nil {
-		t.Fatalf(`Expected to be succeed but failed`)
-	}
-	if app.Title != "Valid App 1" {
-		t.Fatalf("failed")
-	}
+`,
 }
 
-func TestMatchRule(t *testing.T) {
-	var tests = []struct {
-		ruleText       string
-		expectedResult bool
-		expectedErrMsg string
-	}{
-		{
-			"title[like]=App",
-			true,
-			"",
-		},
-		{
-			"title=App",
-			false,
-			"",
-		},
-		{
-			"title=Valid App 1",
-			true,
-			"",
-		},
-		{
-			"maintainer.name[like]=second",
-			true,
-			"",
-		},
-		{
-			"maintainer.name[like]=third",
-			false,
-			"",
-		},
-	}
-
-	app, err := Parse([]byte(sampleInput))
-	if err != nil {
-		t.Fatalf("Failed to parse app meta.")
-	}
-
-	for _, tt := range tests {
-		testName := tt.ruleText
-		t.Run(testName, func(t *testing.T) {
-			rule, err := filter.ParseRule(tt.ruleText)
-			if err != nil {
-				t.Fatalf("Failed to parse rule %s", tt.ruleText)
-			}
-			match, err := app.MatchRule(*rule)
-			if match != tt.expectedResult {
-				t.Errorf("Expect '%v' but got '%v'.", tt.expectedResult, match)
-			}
-			if err != nil {
-				if err.Error() != tt.expectedErrMsg {
-					t.Errorf("Expect err to be '%s' but got '%s'.", tt.expectedErrMsg, err.Error())
-				}
-			}
-		})
+func TestString(t *testing.T) {
+	if app.String() != "App: Valid App 1@0.0.1" {
+		t.Errorf("Failed")
 	}
 }

--- a/src/app/store.go
+++ b/src/app/store.go
@@ -62,7 +62,7 @@ func (s *Store) GetByTitleAndVersion(title string, version semver.Version) *Meta
 func (s *Store) List(ruleSet filter.RuleSet) ([]Meta, error) {
 	result := make([]Meta, 0)
 	for _, app := range s.apps {
-		matched, err := app.MatchRuleSet(ruleSet)
+		matched, err := ruleSet.Match(app)
 		if err != nil {
 			return result, errors.New(fmt.Sprintf("Error occurred during searching app: %s", err))
 		}

--- a/src/app/store.go
+++ b/src/app/store.go
@@ -2,7 +2,6 @@
 package app
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
@@ -22,11 +21,11 @@ var modifyLock sync.Mutex
 // It returns error if the store already contains an app with the same title and version.
 func (s *Store) Add(app Meta) error {
 	if app.Version == semver.Empty {
-		return errors.New(fmt.Sprintf("App '%s' lacks of version or the version could not be '%s'.)", app.Title, app.Version))
+		return fmt.Errorf("App '%s' lacks of version or the version could not be '%s'.)", app.Title, app.Version)
 	}
 
 	if s.GetByTitleAndVersion(app.Title, app.Version) != nil {
-		return errors.New(fmt.Sprintf("App '%s' with version '%s' already exists.", app.Title, app.Version))
+		return fmt.Errorf("App '%s' with version '%s' already exists.", app.Title, app.Version)
 	}
 
 	modifyLock.Lock()
@@ -64,7 +63,7 @@ func (s *Store) List(ruleSet filter.RuleSet) ([]Meta, error) {
 	for _, app := range s.apps {
 		matched, err := ruleSet.Match(app)
 		if err != nil {
-			return result, errors.New(fmt.Sprintf("Error occurred during searching app: %s", err))
+			return result, fmt.Errorf("Error occurred during searching app: %s", err)
 		}
 
 		if matched {

--- a/src/app/store_test.go
+++ b/src/app/store_test.go
@@ -145,8 +145,8 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected to be 3 items but got %d", len(result))
 	}
 
-	rule, _ := filter.ParseRule("title=App1")
-	ruleSet.AddRule(*rule)
+	rule, _ := filter.ParseRule("title=App1", app1v1)
+	ruleSet.AddRule(rule)
 
 	result, err = store.List(ruleSet)
 	if err != nil {
@@ -156,15 +156,12 @@ func TestList(t *testing.T) {
 		t.Errorf("Expected to be 2 items but got %d", len(result))
 	}
 
-	rule, _ = filter.ParseRule("unknown=App1")
-	ruleSet.AddRule(*rule)
+	rule, _ = filter.ParseRule("title=NonExist", app1v1)
+	ruleSet.AddRule(rule)
 
 	result, err = store.List(ruleSet)
 	if err != nil {
-		expectedErrMsg := "Error occurred during searching app: Unsupported rule for field 'unknown'"
-		if err.Error() != expectedErrMsg {
-			t.Errorf("Expected error message to be '%s' but got '%s'", expectedErrMsg, err.Error())
-		}
+		t.Errorf("Expected to be no error but got '%s'", err.Error())
 	}
 	if len(result) != 0 {
 		t.Errorf("Expected to be 0 items but got %d", len(result))

--- a/src/filter/op/operator.go
+++ b/src/filter/op/operator.go
@@ -1,8 +1,10 @@
+// Package op provides operators used in filter evaluation.
 package op
 
 import (
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 )
 
@@ -15,15 +17,57 @@ import (
 //
 // .  /employees?name=Tommy
 //
-type Operator string
+type Operator struct {
+	Name   string
+	Symbol string
+	OpText string
+}
 
-const (
-	Equals      Operator = "=="
-	Like                 = "like"
-	LessThan             = "<"
-	GreaterThan          = ">"
-	Unknown              = "Unknown"
+var (
+	Equals = Operator{
+		Name:   "Equals",
+		Symbol: "==",
+		OpText: "eq",
+	}
+
+	Like = Operator{
+		Name:   "Like",
+		Symbol: "like",
+		OpText: "like",
+	}
+
+	LessThan = Operator{
+		Name:   "LessThan",
+		Symbol: "<",
+		OpText: "lt",
+	}
+
+	GreaterThan = Operator{
+		Name:   "GreaterThan",
+		Symbol: ">",
+		OpText: "gt",
+	}
+
+	// More operators can be added here.
+
+	Unknown = Operator{}
 )
+
+// LessThanComparer describes the operation to compare whether less than a given value.
+type LessThanComparer interface {
+	LessThan(another interface{}) bool
+}
+
+// GreaterThanComparer describes the operation to compare whether greater than a given value.
+type GreaterThanComparer interface {
+	GreaterThan(another interface{}) bool
+}
+
+// ValueComparer describes operations of comparing two given objects.
+type ValueComparer interface {
+	LessThanComparer
+	GreaterThanComparer
+}
 
 // Parse parses given text into Operation.
 // It returns the corresponding Operation object when parse succeed
@@ -41,4 +85,105 @@ func Parse(text string) (Operator, error) {
 	default:
 		return Unknown, errors.New(fmt.Sprintf("Unrecognized operator type '%s'", text))
 	}
+}
+
+// IsValidType returns whether a given object is valid for this operator.
+// e.g.
+//   1. When the operator is "Like", it only accepts value in string type.
+//   2. When the operator is "lt" or "gt", it accepts numbers or comparable objects, but no strings.
+//   3. etc.
+func (op Operator) IsValidType(value interface{}) bool {
+	switch op {
+	case Equals:
+		// 'Equals' operator is available for any type
+		return true
+	case Like:
+		// 'Like' operator only valid for string types
+		return isStringType(value)
+	case LessThan, GreaterThan:
+		// 'LessThan', 'GreaterThan' operators can accept either a number
+		// or an object which implements 'ValueComparer' interface.
+		return isNumberType(value) || isValueComparerType(value)
+	}
+
+	return false
+}
+
+// Evaluate applies the incomingValue to the operator and baseValue.
+// e.g.
+//   For LessThan operator, given incomingValue=5, baseValue=10, will return true since 5<10.
+//   The baseValue is typically set by a filter.Rule object,
+//   which is parsed from querystring like: age[lt]=10
+//   And the incomingValue is the value of the user's input, in this example the value is 5.
+func (op Operator) Evaluate(incomingValue interface{}, baseValue interface{}) (bool, error) {
+	// Make sure incomingValue is the same type with baseValue.
+	if reflect.ValueOf(incomingValue).Type() != reflect.ValueOf(baseValue).Type() {
+		return false, fmt.Errorf("TypeMismatch: Expects incoming value to be '%T' type but was '%T'", baseValue, incomingValue)
+	}
+	// Usually we have already verified the type of baseValue to be compatible to the operator.
+	// And we have already made sure the types of incomingValue and baseValue are the same.
+	// So, the type of incomingValue must be compatible with the operator.
+	// However, we do another type check here to make sure for the assumption.
+	if !op.IsValidType(incomingValue) {
+		return false, fmt.Errorf("Operator '%s' does not support the incoming values in %T type.", op, incomingValue)
+	}
+
+	switch op {
+	case Equals:
+		return incomingValue == baseValue, nil
+	case Like:
+		return strings.Contains(incomingValue.(string), baseValue.(string)), nil
+	case LessThan:
+		if isNumberType(baseValue) {
+			// Assume all number types are 'int'.
+			// TODO: adapt to all the number types.
+			return incomingValue.(int) < baseValue.(int), nil
+		} else if isValueComparerType(baseValue) {
+			return incomingValue.(ValueComparer).LessThan(baseValue.(ValueComparer)), nil
+		} else {
+			panic("Should never fall into this branch.")
+		}
+	case GreaterThan:
+		if isNumberType(baseValue) {
+			return incomingValue.(int) > baseValue.(int), nil
+		} else if isValueComparerType(baseValue) {
+			return incomingValue.(ValueComparer).GreaterThan(baseValue.(ValueComparer)), nil
+		} else {
+			panic("Should never fall into this branch.")
+		}
+	default:
+		return false, fmt.Errorf("Unknown operator '%s'", op)
+	}
+}
+
+// String returns a text representation of this object.
+func (op Operator) String() string {
+	return op.Name
+}
+
+func isNumberType(value interface{}) bool {
+	switch value.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
+		return true
+	}
+
+	return false
+}
+
+func isStringType(value interface{}) bool {
+	switch value.(type) {
+	case string:
+		return true
+	}
+
+	return false
+}
+
+func isValueComparerType(value interface{}) bool {
+	switch value.(type) {
+	case ValueComparer:
+		return true
+	}
+
+	return false
 }

--- a/src/filter/op/operator_test.go
+++ b/src/filter/op/operator_test.go
@@ -1,6 +1,44 @@
 package op
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
+
+type MyStruct struct {
+	Field1 int
+	Field2 string
+}
+
+type Version struct {
+	Major int
+	Minor int
+}
+
+type ComparableVersion struct {
+	Major int
+	Minor int
+}
+
+func (v ComparableVersion) LessThan(another interface{}) bool {
+	if v.Major < another.(ComparableVersion).Major {
+		return true
+	} else if v.Minor < another.(ComparableVersion).Minor {
+		return true
+	}
+
+	return false
+}
+
+func (v ComparableVersion) GreaterThan(another interface{}) bool {
+	if v.Major > another.(ComparableVersion).Major {
+		return true
+	} else if v.Minor > another.(ComparableVersion).Minor {
+		return true
+	}
+
+	return false
+}
 
 func TestParse(t *testing.T) {
 	var tests = []struct {
@@ -21,13 +59,179 @@ func TestParse(t *testing.T) {
 		testname := tt.input
 		t.Run(testname, func(t *testing.T) {
 			op, err := Parse(tt.input)
-			if op != tt.want {
-				t.Errorf("Expect '%s' but got '%s'.", tt.want, op)
+			if op.Name != tt.want.Name {
+				t.Errorf("Expect '%s' but got '%s'.", tt.want.Name, op.Name)
 			}
 			if err != nil {
 				if err.Error() != tt.errorMessage {
 					t.Errorf("Expect error message '%s' but got '%s'.", tt.errorMessage, err.Error())
 				}
+			}
+		})
+	}
+}
+
+func TestIsValidType(t *testing.T) {
+	var i int
+	var s string
+	var v Version
+	var cv ComparableVersion
+
+	var tests = []struct {
+		op       Operator
+		value    interface{}
+		expected bool
+	}{
+		{Equals, i, true},
+		{Equals, s, true},
+		{Equals, v, true},
+		{Equals, cv, true},
+		{Like, i, false},
+		{Like, s, true},
+		{Like, v, false},
+		{Like, cv, false},
+		{LessThan, i, true},
+		{LessThan, s, false},
+		{LessThan, v, false},
+		{LessThan, cv, true},
+		{GreaterThan, i, true},
+		{GreaterThan, s, false},
+		{GreaterThan, v, false},
+		{GreaterThan, cv, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.op.Name, func(t *testing.T) {
+			valid := tt.op.IsValidType(tt.value)
+			if tt.expected != valid {
+				t.Errorf("Expected to be '%v' but got '%v'", tt.expected, valid)
+			}
+		})
+	}
+}
+
+func TestEvaluate(t *testing.T) {
+	var tests = []struct {
+		operator      Operator
+		incomingValue interface{}
+		threshold     interface{}
+		want          bool
+		errorMessage  string
+	}{
+		{Equals, 0, 0, true, ""},
+		{Equals, 0, 1, false, ""},
+		{Equals, "a", "a", true, ""},
+		{Equals, "a", "b", false, ""},
+		{Equals, MyStruct{Field1: 42, Field2: "Hello"}, MyStruct{Field1: 42, Field2: "Hello"}, true, ""},
+		{Equals, MyStruct{Field1: 42, Field2: "Hello"}, MyStruct{Field1: 0, Field2: "Hello"}, false, ""},
+		{Equals, MyStruct{Field1: 42, Field2: "Hello"}, MyStruct{Field1: 42, Field2: "World"}, false, ""},
+		{Like, "abcde", "abc", true, ""},
+		{Like, "abc", "abc", true, ""},
+		{Like, "abc", "abcde", false, ""},
+		{Like, 1, 2, false, "Operator 'Like' does not support the incoming values in int type."},
+		{LessThan, 1, 2, true, ""},
+		{LessThan, 2, 1, false, ""},
+		{LessThan, Version{Major: 1, Minor: 0}, Version{Major: 1, Minor: 1}, false, "Operator 'LessThan' does not support the incoming values in op.Version type."},
+		{LessThan, ComparableVersion{Major: 1, Minor: 0}, ComparableVersion{Major: 1, Minor: 1}, true, ""},
+		{GreaterThan, 1, 2, false, ""},
+		{GreaterThan, 2, 1, true, ""},
+		{GreaterThan, Version{Major: 1, Minor: 0}, Version{Major: 1, Minor: 1}, false, "Operator 'GreaterThan' does not support the incoming values in op.Version type."},
+		{GreaterThan, ComparableVersion{Major: 1, Minor: 0}, ComparableVersion{Major: 1, Minor: 1}, false, ""},
+		{GreaterThan, ComparableVersion{Major: 1, Minor: 0}, 1, false, "TypeMismatch: Expects incoming value to be 'int' type but was 'op.ComparableVersion'"},
+	}
+
+	for _, tt := range tests {
+		testname := tt.operator.Name
+		t.Run(testname, func(t *testing.T) {
+			res, err := tt.operator.Evaluate(tt.incomingValue, tt.threshold)
+			if res != tt.want {
+				t.Errorf("Expect to be '%v' but got '%v'", tt.want, res)
+			}
+			if err != nil {
+				if err.Error() != tt.errorMessage {
+					t.Errorf("Expect error message '%s' but got '%s'.", tt.errorMessage, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestIsNumberType(t *testing.T) {
+	var v Version
+	var cv ComparableVersion
+
+	var tests = []struct {
+		value interface{}
+		want  bool
+	}{
+		{1, true},
+		{"", false},
+		{1.1, true},
+		{true, false},
+		{v, false},
+		{cv, false},
+	}
+
+	for _, tt := range tests {
+		testName := fmt.Sprintf("%v", tt.value)
+		t.Run(testName, func(t *testing.T) {
+			actual := isNumberType(tt.value)
+			if tt.want != actual {
+				t.Errorf("isNumberType(%v) expected to be %v but got %v", tt.value, tt.want, actual)
+			}
+		})
+	}
+}
+
+func TestIsStringType(t *testing.T) {
+	var v Version
+	var cv ComparableVersion
+
+	var tests = []struct {
+		value interface{}
+		want  bool
+	}{
+		{1, false},
+		{"", true},
+		{1.1, false},
+		{true, false},
+		{v, false},
+		{cv, false},
+	}
+
+	for _, tt := range tests {
+		testName := fmt.Sprintf("%v", tt.value)
+		t.Run(testName, func(t *testing.T) {
+			actual := isStringType(tt.value)
+			if tt.want != actual {
+				t.Errorf("isStringType(%v) expected to be %v but got %v", tt.value, tt.want, actual)
+			}
+		})
+	}
+}
+
+func TestIsValueComparerType(t *testing.T) {
+	var v Version
+	var cv ComparableVersion
+
+	var tests = []struct {
+		value interface{}
+		want  bool
+	}{
+		{1, false},
+		{"", false},
+		{1.1, false},
+		{true, false},
+		{v, false},
+		{cv, true},
+	}
+
+	for _, tt := range tests {
+		testName := fmt.Sprintf("%v", tt.value)
+		t.Run(testName, func(t *testing.T) {
+			actual := isValueComparerType(tt.value)
+			if tt.want != actual {
+				t.Errorf("isValueComparerType(%v) expected to be %v but got %v", tt.value, tt.want, actual)
 			}
 		})
 	}

--- a/src/filter/rule_test.go
+++ b/src/filter/rule_test.go
@@ -1,11 +1,182 @@
 package filter
 
 import (
-	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/zzn2/demo/appstore/filter/op"
+	"github.com/zzn2/demo/appstore/semver"
 )
+
+type User struct {
+	FirstName string
+	LastName  string
+	Age       int
+	Version   semver.Version
+}
+
+func TestParseRule(t *testing.T) {
+	var u User
+	var tests = []struct {
+		input          string
+		expectedRule   Rule
+		expectedErrMsg string
+	}{
+		{
+			"FirstName=Tom",
+			Rule{FieldName: "FirstName", Op: op.Equals, Value: "Tom"},
+			"",
+		},
+		{
+			"firstname=Tom",
+			Rule{FieldName: "firstname", Op: op.Equals, Value: "Tom"},
+			"",
+		},
+		{
+			"name=Tom",
+			Rule{},
+			"Failed to create rule: Field with name 'name' does not exist.",
+		},
+		{
+			"FirstName[like]=Tom",
+			Rule{FieldName: "FirstName", Op: op.Like, Value: "Tom"},
+			"",
+		},
+		{
+			"age[lt]=20",
+			Rule{FieldName: "age", Op: op.LessThan, Value: 20},
+			"",
+		},
+		{
+			"age[dummy]=20",
+			Rule{},
+			"Unrecognized operator type 'dummy'",
+		},
+		{
+			"version[lt]=0.0.1",
+			Rule{FieldName: "version", Op: op.LessThan, Value: semver.Version{Major: 0, Minor: 0, Patch: 1}},
+			"",
+		},
+		{
+			"version[lt]=0.0.a",
+			Rule{},
+			`Failed to create rule: Failed to parse version '0.0.a': Invalid character(s) found in number "a"`,
+		},
+		{
+			"version[like]=0.0.1",
+			Rule{},
+			"Failed to create rule: Type 'semver.Version' does not support 'Like' operator",
+		},
+		{
+			"illegal/keyformat=1",
+			Rule{},
+			"Malformed input key format: 'illegal/keyformat'",
+		},
+	}
+
+	for _, tt := range tests {
+		testName := tt.input
+		t.Run(testName, func(t *testing.T) {
+			rule, err := ParseRule(tt.input, u)
+			if rule != tt.expectedRule {
+				t.Errorf("Expect '%s' but got '%s'.", tt.expectedRule, rule)
+			}
+			if err != nil {
+				if err.Error() != tt.expectedErrMsg {
+					t.Errorf("Expect err to be '%s' but got '%s'.", tt.expectedErrMsg, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestEvaluate(t *testing.T) {
+	var u User
+	var tests = []struct {
+		ruleText        string
+		valueToEvaluate interface{}
+		expectedResult  bool
+		expectedErrMsg  string
+	}{
+		{
+			"FirstName=Tom",
+			"Tom",
+			true,
+			"",
+		},
+		{
+			"LastName=Tom",
+			"Green",
+			false,
+			"",
+		},
+		{
+			"LastName=ree",
+			"Green",
+			false,
+			"",
+		},
+		{
+			"LastName[Like]=ree",
+			"Green",
+			true,
+			"",
+		},
+		{
+			"LastName[Like]=Gre",
+			"Green",
+			true,
+			"",
+		},
+		{
+			"LastName[Like]=een",
+			"Green",
+			true,
+			"",
+		},
+		{
+			"LastName[Like]=Green",
+			"Green",
+			true,
+			"",
+		},
+		{
+			"Age[lt]=25",
+			20,
+			true,
+			"",
+		},
+		{
+			"Age[gt]=25",
+			20,
+			false,
+			"",
+		},
+		{
+			"Age[gt]=25",
+			"20",
+			false,
+			"Failed to evaluate 'Rule: Age gt 25 (int)': TypeMismatch: Expects incoming value to be 'int' type but was 'string'",
+		},
+	}
+
+	for _, tt := range tests {
+		testName := strings.NewReplacer("[", "_", "]", "_").Replace(tt.ruleText)
+		t.Run(testName, func(t *testing.T) {
+			rule, _ := ParseRule(tt.ruleText, u)
+			match, err := rule.Evaluate(tt.valueToEvaluate)
+			if match != tt.expectedResult {
+				t.Errorf("Expect '%v' but got '%v'.", tt.expectedResult, match)
+			}
+			if err != nil {
+				if err.Error() != tt.expectedErrMsg {
+					t.Errorf("Expect err to be '%s' but got '%s'.", tt.expectedErrMsg, err.Error())
+				}
+			}
+		})
+	}
+}
 
 func TestGetNameAndOp(t *testing.T) {
 	var tests = []struct {
@@ -77,131 +248,157 @@ func TestGetNameAndOp(t *testing.T) {
 	}
 }
 
-func TestParseRule(t *testing.T) {
+func TestGetFieldByName(t *testing.T) {
+	var u User
 	var tests = []struct {
-		input           string
-		expectedRuleStr string
-		expectedErrMsg  string
+		testName          string
+		obj               interface{}
+		fieldName         string
+		expectedToBeValid bool
 	}{
 		{
-			"name=Tom",
-			"Rule: name == Tom",
-			"",
+			"Get field name",
+			u,
+			"FirstName",
+			true,
 		},
 		{
-			"name[like]=Tom",
-			"Rule: name like Tom",
-			"",
+			"Get field name",
+			u,
+			"firstname",
+			true,
 		},
 		{
-			"age[lt]=20",
-			"Rule: age < 20",
-			"",
+			"Get field name",
+			u,
+			"Age",
+			true,
 		},
 		{
-			"age[dummy]=20",
-			"<nil>",
-			"Unrecognized operator type 'dummy'",
-		},
-		{
-			"illegal/keyformat=1",
-			"<nil>",
-			"Malformed input key format: 'illegal/keyformat'",
+			"Get field name",
+			u,
+			"Unknown",
+			false,
 		},
 	}
 
 	for _, tt := range tests {
-		testName := tt.input
-		t.Run(testName, func(t *testing.T) {
-			rule, err := ParseRule(tt.input)
-			str := fmt.Sprintf("%s", rule)
-			if str != tt.expectedRuleStr {
-				t.Errorf("Expect '%s' but got '%s'.", tt.expectedRuleStr, str)
-			}
-			if err != nil {
-				if err.Error() != tt.expectedErrMsg {
-					t.Errorf("Expect err to be '%s' but got '%s'.", tt.expectedErrMsg, err.Error())
-				}
+		t.Run(tt.testName, func(t *testing.T) {
+			res := getFieldByName(tt.obj, tt.fieldName)
+			valid := res.IsValid()
+			if valid != tt.expectedToBeValid {
+				t.Errorf("IsValid() expected to be '%v' but got '%v'", tt.expectedToBeValid, valid)
 			}
 		})
 	}
 }
 
-func TestEvaluate(t *testing.T) {
+func TestParseText(t *testing.T) {
+	var i int
+	var i32 int32
+	var i64 int64
+	var u uint
+	var u32 uint32
+	var u64 uint64
+	var s string
+	var v semver.Version
+
 	var tests = []struct {
-		ruleText        string
-		valueToEvaluate string
-		expectedResult  bool
-		expectedErrMsg  string
+		testName             string
+		textToParse          string
+		parseAsType          reflect.Type
+		expectedResult       interface{}
+		expectedErrorMessage string
 	}{
 		{
-			"FirstName=Tom",
-			"Tom",
-			true,
+			"int",
+			"42",
+			reflect.TypeOf(i),
+			int(42),
 			"",
 		},
 		{
-			"LastName=Tom",
-			"Green",
-			false,
+			"int32",
+			"42",
+			reflect.TypeOf(i32),
+			int32(42),
 			"",
 		},
 		{
-			"LastName=ree",
-			"Green",
-			false,
+			"int64",
+			"42",
+			reflect.TypeOf(i64),
+			int64(42),
 			"",
 		},
 		{
-			"LastName[Like]=ree",
-			"Green",
-			true,
+			"int64_error",
+			"a",
+			reflect.TypeOf(i64),
+			int64(0),
+			"Invalid integer format: strconv.ParseInt: parsing \"a\": invalid syntax",
+		},
+		{
+			"uint",
+			"42",
+			reflect.TypeOf(u),
+			uint(42),
 			"",
 		},
 		{
-			"LastName[Like]=Gre",
-			"Green",
-			true,
+			"uint32",
+			"42",
+			reflect.TypeOf(u32),
+			uint32(42),
 			"",
 		},
 		{
-			"LastName[Like]=een",
-			"Green",
-			true,
+			"uint64",
+			"42",
+			reflect.TypeOf(u64),
+			uint64(42),
 			"",
 		},
 		{
-			"LastName[Like]=Green",
-			"Green",
-			true,
+			"uint64_error",
+			"-1",
+			reflect.TypeOf(u64),
+			uint64(0),
+			"Invalid integer format: strconv.ParseUint: parsing \"-1\": invalid syntax",
+		},
+		{
+			"string",
+			"hello world",
+			reflect.TypeOf(s),
+			"hello world",
 			"",
 		},
 		{
-			"Age[lt]=25",
-			"20",
-			false,
-			"Operator '<' currently unsupported.",
+			"version",
+			"0.0.1",
+			reflect.TypeOf(v),
+			semver.Version{Major: 0, Minor: 0, Patch: 1},
+			"",
 		},
 		{
-			"Age[gt]=25",
-			"20",
-			false,
-			"Operator '>' currently unsupported.",
+			"version_error",
+			"0.0.a",
+			reflect.TypeOf(v),
+			semver.Version{Major: 0, Minor: 0, Patch: 0},
+			"Failed to parse version '0.0.a': Invalid character(s) found in number \"a\"",
 		},
 	}
 
 	for _, tt := range tests {
-		testName := tt.ruleText
-		t.Run(testName, func(t *testing.T) {
-			rule, _ := ParseRule(tt.ruleText)
-			match, err := rule.Evaluate(tt.valueToEvaluate)
-			if match != tt.expectedResult {
-				t.Errorf("Expect '%v' but got '%v'.", tt.expectedResult, match)
-			}
+		t.Run(tt.testName, func(t *testing.T) {
+			parsed, err := parseText(tt.textToParse, tt.parseAsType)
 			if err != nil {
-				if err.Error() != tt.expectedErrMsg {
-					t.Errorf("Expect err to be '%s' but got '%s'.", tt.expectedErrMsg, err.Error())
+				if err.Error() != tt.expectedErrorMessage {
+					t.Errorf("Expected error message '%s' but got '%s'", tt.expectedErrorMessage, err.Error())
 				}
+			}
+			if parsed != tt.expectedResult {
+				t.Errorf("Expected '%v' (%T) but got '%v' (%T)", tt.expectedResult, tt.expectedResult, parsed, parsed)
 			}
 		})
 	}

--- a/src/filter/ruleset.go
+++ b/src/filter/ruleset.go
@@ -14,27 +14,45 @@ type RuleSet struct {
 
 // Create accepts a map generated from query params and parse them
 // as a set of rules and build them inside the RuleSet.
-func CreateRuleSet(queryParams map[string][]string) (*RuleSet, error) {
-	flt := &RuleSet{}
+func CreateRuleSet(queryParams map[string][]string, applyToObj interface{}) (RuleSet, error) {
+	rs := RuleSet{}
 	for key, value := range queryParams {
 		if len(value) > 1 {
-			return nil, errors.New(fmt.Sprintf("Key '%s' appeared multiple times with values of '%s'. Currently this case is not unsupported.", key, strings.Join(value, ", ")))
+			return rs, errors.New(fmt.Sprintf("Key '%s' appeared multiple times with values of '%s'. Currently this case is not unsupported.", key, strings.Join(value, ", ")))
 		}
 
-		rule, err := NewRule(key, value[0])
+		rule, err := NewRule(key, value[0], applyToObj)
 		if err != nil {
-			return nil, err
+			return rs, err
 		}
-		flt.AddRule(*rule)
+
+		rs.AddRule(rule)
 	}
-	return flt, nil
+	return rs, nil
 }
 
 // AddRule adds a new rule to the given RuleSet.
-func (f *RuleSet) AddRule(rule Rule) {
-	f.Rules = append(f.Rules, rule)
+func (rs *RuleSet) AddRule(rule Rule) {
+	rs.Rules = append(rs.Rules, rule)
 }
 
-func (f RuleSet) String() string {
-	return fmt.Sprintf("RuleSet: %s", f.Rules)
+// Match evaluates whether this Meta matches the given ruleset.
+// It returns true if matches otherwise returns false.
+// If any unexpected errors occurred during match operation, return the error.
+func (rs RuleSet) Match(obj interface{}) (bool, error) {
+	for _, rule := range rs.Rules {
+		match, err := rule.Match(obj)
+		if err != nil {
+			return false, err
+		}
+		if !match {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (rs RuleSet) String() string {
+	return fmt.Sprintf("RuleSet: %s", rs.Rules)
 }

--- a/src/filter/ruleset_test.go
+++ b/src/filter/ruleset_test.go
@@ -2,13 +2,22 @@ package filter
 
 import (
 	"testing"
+
+	"github.com/zzn2/demo/appstore/semver"
 )
+
+type Meta struct {
+	Title   string
+	Version semver.Version
+}
+
+var app Meta
 
 func TestCreate(t *testing.T) {
 	ruleSet, err := CreateRuleSet(map[string][]string{
 		"title[like]": {"App"},
 		"version":     {"0.0.1"},
-	})
+	}, app)
 	if err != nil {
 		t.Errorf("Failed to create RuleSet: %e", err)
 	}
@@ -21,7 +30,7 @@ func TestCreate(t *testing.T) {
 func TestCreate_DuplicateKey(t *testing.T) {
 	ruleSet, err := CreateRuleSet(map[string][]string{
 		"title": {"App1", "App2"},
-	})
+	}, app)
 	if err == nil {
 		t.Errorf("Expected to have error but had none.")
 	}
@@ -31,15 +40,15 @@ func TestCreate_DuplicateKey(t *testing.T) {
 		t.Errorf("Expected to have error '%s' but got '%s'", expectedErrMsg, err.Error())
 	}
 
-	if ruleSet != nil {
-		t.Errorf("Expected ruleSet to be nil but not nil.")
+	if len(ruleSet.Rules) != 0 {
+		t.Errorf("Expected ruleSet to be empty but not empty.")
 	}
 }
 
 func TestCreate_RuleCreationFailure(t *testing.T) {
 	ruleSet, err := CreateRuleSet(map[string][]string{
 		"title[dummy]": {"App1"},
-	})
+	}, app)
 	if err == nil {
 		t.Errorf("Expected to have error but had none.")
 	}
@@ -49,7 +58,7 @@ func TestCreate_RuleCreationFailure(t *testing.T) {
 		t.Errorf("Expected to have error '%s' but got '%s'", expectedErrMsg, err.Error())
 	}
 
-	if ruleSet != nil {
-		t.Errorf("Expected ruleSet to be nil but not nil.")
+	if len(ruleSet.Rules) != 0 {
+		t.Errorf("Expected ruleSet to be empty but not empty.")
 	}
 }

--- a/src/semver/version.go
+++ b/src/semver/version.go
@@ -12,39 +12,16 @@ import (
 	"strings"
 )
 
+// Version represents a Semantic Version.
+// However here only implements a subset of the full spec for demo usage.
 type Version struct {
 	Major uint64
 	Minor uint64
 	Patch uint64
 }
 
+// Empty represents the zero value of Version.
 var Empty = Version{}
-
-func containsOnly(s string, set string) bool {
-	return strings.IndexFunc(s, func(r rune) bool {
-		return !strings.ContainsRune(set, r)
-	}) == -1
-}
-
-func hasLeadingZeroes(s string) bool {
-	return len(s) > 1 && s[0] == '0'
-}
-
-func parseSection(text string) (uint64, error) {
-	if !containsOnly(text, "0123456789") {
-		return 0, fmt.Errorf("Invalid character(s) found in number %q", text)
-	}
-	if hasLeadingZeroes(text) {
-		return 0, fmt.Errorf("Version sections must not contain leading zeroes: %q", text)
-	}
-
-	res, err := strconv.ParseUint(text, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-
-	return res, nil
-}
 
 // Parse parses a text into a Version object.
 // errors will be returned if the text is not a valid format.
@@ -76,6 +53,16 @@ func Parse(s string) (Version, error) {
 	return v, nil
 }
 
+// LessThan checks whether the current version is less than another given version.
+func (v Version) LessThan(another interface{}) bool {
+	return v.compareTo(another) < 0
+}
+
+// GreaterThan checks whether the current version is greater than another given version.
+func (v Version) GreaterThan(another interface{}) bool {
+	return v.compareTo(another) > 0
+}
+
 // UnmarshalYAML will be called when deserializing a Version object from part of YAML text.
 func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var text string
@@ -84,7 +71,12 @@ func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	version, err := Parse(text)
+	return v.UnmarshalText([]byte(text))
+}
+
+// UnmarshalText reads list of bytes and parse them into Version object.
+func (v *Version) UnmarshalText(text []byte) error {
+	version, err := Parse(string(text))
 	if err != nil {
 		return err
 	}
@@ -103,4 +95,56 @@ func (v Version) MarshalJSON() ([]byte, error) {
 // String returns the string representation of the Version object.
 func (v Version) String() string {
 	return fmt.Sprintf("%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+func (v Version) compareTo(another interface{}) int {
+	if _, ok := another.(Version); !ok {
+		panic("Expected Version type.")
+	}
+
+	if v.Major < another.(Version).Major {
+		return -1
+	} else if v.Major > another.(Version).Major {
+		return 1
+	} else {
+		if v.Minor < another.(Version).Minor {
+			return -1
+		} else if v.Minor > another.(Version).Minor {
+			return 1
+		} else {
+			if v.Patch < another.(Version).Patch {
+				return -1
+			} else if v.Patch > another.(Version).Patch {
+				return 1
+			} else {
+				return 0
+			}
+		}
+	}
+}
+
+func containsOnly(s string, set string) bool {
+	return strings.IndexFunc(s, func(r rune) bool {
+		return !strings.ContainsRune(set, r)
+	}) == -1
+}
+
+func hasLeadingZeroes(s string) bool {
+	return len(s) > 1 && s[0] == '0'
+}
+
+func parseSection(text string) (uint64, error) {
+	if !containsOnly(text, "0123456789") {
+		return 0, fmt.Errorf("Invalid character(s) found in number %q", text)
+	}
+	if hasLeadingZeroes(text) {
+		return 0, fmt.Errorf("Version sections must not contain leading zeroes: %q", text)
+	}
+
+	res, err := strconv.ParseUint(text, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return res, nil
 }

--- a/src/semver/version_test.go
+++ b/src/semver/version_test.go
@@ -1,8 +1,11 @@
 package semver
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
-func TestEvaluate(t *testing.T) {
+func TestParse(t *testing.T) {
 	var tests = []struct {
 		text         string
 		expected     Version
@@ -27,6 +30,94 @@ func TestEvaluate(t *testing.T) {
 				if err.Error() != tt.errorMessage {
 					t.Errorf("Expect error message '%s' but got '%s'.", tt.errorMessage, err.Error())
 				}
+			}
+		})
+	}
+}
+
+func TestLessThan(t *testing.T) {
+	var tests = []struct {
+		v1       Version
+		v2       Version
+		lessThan bool
+	}{
+		{
+			Version{0, 1, 0},
+			Version{1, 0, 0},
+			true,
+		},
+		{
+			Version{0, 1, 0},
+			Version{0, 2, 0},
+			true,
+		},
+		{
+			Version{0, 0, 1},
+			Version{0, 0, 2},
+			true,
+		},
+		{
+			Version{1, 1, 0},
+			Version{0, 2, 0},
+			false,
+		},
+		{
+			Version{0, 0, 1},
+			Version{0, 0, 1},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := fmt.Sprintf("%s < %s: %v", tt.v1, tt.v2, tt.lessThan)
+		t.Run(testName, func(t *testing.T) {
+			res := tt.v1.LessThan(tt.v2)
+			if res != tt.lessThan {
+				t.Errorf("Expected to be '%v' but got '%v'", tt.lessThan, res)
+			}
+		})
+	}
+}
+
+func TestGreaterThan(t *testing.T) {
+	var tests = []struct {
+		v1          Version
+		v2          Version
+		greaterThan bool
+	}{
+		{
+			Version{0, 1, 0},
+			Version{1, 0, 0},
+			false,
+		},
+		{
+			Version{0, 1, 0},
+			Version{0, 2, 0},
+			false,
+		},
+		{
+			Version{0, 0, 1},
+			Version{0, 0, 2},
+			false,
+		},
+		{
+			Version{1, 1, 0},
+			Version{0, 2, 0},
+			true,
+		},
+		{
+			Version{0, 0, 1},
+			Version{0, 0, 1},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		testName := fmt.Sprintf("%s < %s: %v", tt.v1, tt.v2, tt.greaterThan)
+		t.Run(testName, func(t *testing.T) {
+			res := tt.v1.GreaterThan(tt.v2)
+			if res != tt.greaterThan {
+				t.Errorf("Expected to be '%v' but got '%v'", tt.greaterThan, res)
 			}
 		})
 	}

--- a/src/server.go
+++ b/src/server.go
@@ -61,16 +61,18 @@ func getAppByTitleAndVersion(c *gin.Context) {
 }
 
 func listApps(c *gin.Context) {
+	var app app.Meta
 	q := c.Request.URL.Query()
-	flt, err := filter.CreateRuleSet(q)
+	flt, err := filter.CreateRuleSet(q, app)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, responseBodyForError(err))
 		return
 	}
 
-	result, err := store.List(*flt)
+	result, err := store.List(flt)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, responseBodyForError(err))
+		return
 	}
 	c.JSON(http.StatusOK, result)
 }


### PR DESCRIPTION
Improvements in this PR:
* Enriched `op.Operator` from `string` to `struct` to hold more information.
* Added `op.Operator.IsValidType` function to check the whether the value type is compatible to the operator. e.g. `name[gt]=Tom` will generate an error since string type does not compatible "GreaterThan" operator.
* Added `op.Operator.Evaluate` function to evaluate two values with the operator. e.g. `op.LessThan.Evaluate(5, 10)` will return `true`.
* Moved `app.Meta.MatchRuleSet()` to `filter.RuleSet.Match()` (which calls `op.Operator.Evaluate()` under the hood) to make a better architecture. Now `filter.RuleSet` can be used to filter any struct type, not limited to `app.Meta`.
* Enhanced `filter.RuleSet` in self validation. e.g. It generates error when trying to create a filter to a non-existing field in struct.
* Changed `app.Meta.Version` from `string` to Semantic Version (in [previous PR](https://github.com/zzn2/app-store-demo/pull/1)), and also added support to "LessThan" and "GreaterThan" operators to make it possible to filter apps like `GET /v1/apps?title=App1&version[gt]=0.1.0`.
* Other minor updates.